### PR TITLE
added styling for .selected.visted

### DIFF
--- a/less/accordion.less
+++ b/less/accordion.less
@@ -21,15 +21,6 @@
 			}
 		}
 
-		&.selected {
-			background-color: darken(@cyan, 20%);
-			color: @white;
-
-			.accordion-item-title-icon {
-				color: @white;
-			}
-		}
-
 		&.visited {
 			background-color: darken(@cyan, 20%);
 			color: @white;
@@ -44,6 +35,22 @@
 
 				.accordion-item-title-icon {
 					color: @white;
+				}
+			}
+		}
+
+		&.selected {
+			background-color: @turquiose;
+			color: @white;
+
+			.accordion-item-title-icon {
+				color: @white;
+			}
+			&.visited {
+				background-color: @turquiose;
+				.no-touch &:hover {
+					background-color: @turquiose;
+					
 				}
 			}
 		}


### PR DESCRIPTION
added in styling for when an accordion item is selected. it didn't look
like the background colour was being set for .selected (whenever an
accordion item is visited, it's given the class of selected AND visited,
and the visited styling was overriding the background colour of the
selected class).

This addition allows for an accordion item to have a seperate colour for
when the accordion item is selected (and therefore visited). once you
select another item, it reverts back to the .visited background colour.
