### PR TITLE
fix to question button padding & update to responsive text media queries

### DIFF
--- a/less/buttons.less
+++ b/less/buttons.less
@@ -25,6 +25,10 @@
 
 }
 
+.question-component .button, .question-component button {
+    padding: 10px 20px;
+}
+
 .buttons {
     margin-top:@button-margin-top;
     margin-bottom:@button-margin-bottom;

--- a/less/navigation.less
+++ b/less/navigation.less
@@ -11,7 +11,7 @@
     border-bottom:none;
     background-color:@darkGrey;
     box-shadow: 0 2px 5px rgba(0,0,0,0.26);
-    z-index: 9999;
+    z-index: 400;
     
     .ie8 & {
         max-width: @ie8-max-width;

--- a/less/responsive-text.less
+++ b/less/responsive-text.less
@@ -3,7 +3,7 @@
 .desktop-text {
 	display: none;
 
-	@media all and (min-width: (@device-width-small + 1px)) {
+	@media all and (min-width: @device-width-medium) {
 		display: block;
 	}
 }
@@ -11,7 +11,7 @@
 .mobile-text {
 	display: none;
 	
-	@media all and (max-width: @device-width-small) {
+	@media all and (max-width: (@device-width-medium - 1px)) {
 		display: block;
 	}
 }


### PR DESCRIPTION
fix to question button (submit and model/your answer) padding, so the text label doesn't overrun onto the tick/cross circle that appears between the two buttons
