### PR TITLE
Update quicknav.less

### DIFF
--- a/less/src/quicknav.less
+++ b/less/src/quicknav.less
@@ -1,17 +1,17 @@
 // ====================================================================================================
 // Quicknav styling
 // ====================================================================================================
-.quicknav {
+.quicknav-component {
 	.button,
 	button {
 		.no-touch &:hover {
 			&:not([disabled="disabled"]) {
-				&.icon-controls-left:before {
+				.icon-controls-left:before {
 					display: inline-block;
 					.effect-bounceLeftOnce;
 				}
 
-				&.icon-controls-right:before {
+				.icon-controls-right:before {
 					display: inline-block;
 					.effect-bounceRightOnce;
 				}


### PR DESCRIPTION
This theming stopped linking to quicknav once quicknav became its own component instead of the previous extension.